### PR TITLE
Fix Android build configuration for CI

### DIFF
--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -41,3 +41,4 @@ jobs:
         name: snake_game_apk
         path: build/app/outputs/flutter-apk/app-release.apk
         retention-days: 30
+

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk flutter.minSdkVersion
         targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode flutter.versionCode
+        versionName flutter.versionName
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <application
         android:label="snake_game"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android_backup/app/src/main/AndroidManifest.xml
+++ b/android_backup/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- use Flutter Gradle plugin version properties for Android build
- ensure CI workflow file is properly terminated
- use default Android launcher icon to avoid missing resource error in CI build

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6e575888333b2842ad1234f198f