### PR TITLE
Add resume control and best score display

### DIFF
--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -41,3 +41,4 @@ jobs:
         name: snake_game_apk
         path: build/app/outputs/flutter-apk/app-release.apk
         retention-days: 30
+

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk flutter.minSdkVersion
         targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode flutter.versionCode
+        versionName flutter.versionName
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <application
         android:label="snake_game"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android_backup/app/src/main/AndroidManifest.xml
+++ b/android_backup/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,9 @@ class _SnakeGameState extends State<SnakeGame> {
   Direction direction = Direction.right;
   bool isGameRunning = false;
   bool isGameOver = false;
+  bool isPaused = false;
   int score = 0;
+  int bestScore = 0;
   Timer? gameTimer;
   
   final Random random = Random();
@@ -64,6 +66,7 @@ class _SnakeGameState extends State<SnakeGame> {
       direction = Direction.right;
       isGameRunning = true;
       isGameOver = false;
+      isPaused = false;
       score = 0;
     });
     _generateFood();
@@ -77,6 +80,17 @@ class _SnakeGameState extends State<SnakeGame> {
     gameTimer?.cancel();
     setState(() {
       isGameRunning = false;
+      isPaused = true;
+    });
+  }
+
+  void _resumeGame() {
+    setState(() {
+      isGameRunning = true;
+      isPaused = false;
+    });
+    gameTimer = Timer.periodic(const Duration(milliseconds: 200), (timer) {
+      _moveSnake();
     });
   }
 
@@ -87,6 +101,7 @@ class _SnakeGameState extends State<SnakeGame> {
       direction = Direction.right;
       isGameRunning = false;
       isGameOver = false;
+      isPaused = false;
       score = 0;
     });
     _generateFood();
@@ -137,6 +152,9 @@ class _SnakeGameState extends State<SnakeGame> {
       // Check food collision
       if (newHead == food) {
         score++;
+        if (score > bestScore) {
+          bestScore = score;
+        }
         _generateFood();
       } else {
         snake.removeLast();
@@ -149,6 +167,7 @@ class _SnakeGameState extends State<SnakeGame> {
     setState(() {
       isGameRunning = false;
       isGameOver = true;
+      isPaused = false;
     });
   }
 
@@ -187,6 +206,8 @@ class _SnakeGameState extends State<SnakeGame> {
             } else if (event.logicalKey == LogicalKeyboardKey.space) {
               if (isGameRunning) {
                 _pauseGame();
+              } else if (isPaused) {
+                _resumeGame();
               } else if (!isGameOver) {
                 _startGame();
               }
@@ -234,6 +255,15 @@ class _SnakeGameState extends State<SnakeGame> {
                       ),
                       const SizedBox(width: 16),
                       const Icon(Icons.emoji_events, color: Colors.amber, size: 24),
+                      const SizedBox(width: 8),
+                      Text(
+                        '$bestScore',
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -268,8 +298,14 @@ class _SnakeGameState extends State<SnakeGame> {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
                       ElevatedButton(
-                        onPressed: isGameRunning ? _pauseGame : _startGame,
-                        child: Text(isGameRunning ? 'Pause' : 'Start'),
+                        onPressed: isGameRunning
+                            ? _pauseGame
+                            : (isPaused ? _resumeGame : _startGame),
+                        child: Text(
+                          isGameRunning
+                              ? 'Pause'
+                              : (isPaused ? 'Resume' : 'Start'),
+                        ),
                       ),
                       ElevatedButton(
                         onPressed: _resetGame,


### PR DESCRIPTION
## Summary
- use Flutter Gradle plugin version properties for Android build
- ensure CI workflow file is properly terminated
- use default Android launcher icon to avoid missing resource error in CI build
- add pause/resume toggle with new state and resume logic
- track and show best score beside current score

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6e575888333b2842ad1234f198f