### PR TITLE
feat: use black app theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,12 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Snake Game',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+        brightness: Brightness.dark,
+        scaffoldBackgroundColor: Colors.black,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.green,
+          brightness: Brightness.dark,
+        ),
         fontFamily: 'Arial',
         useMaterial3: true,
       ),


### PR DESCRIPTION
## Summary
- use a dark color scheme with black scaffold background

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter build apk --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b206c8e74c8333b56d2506c8336d5a