### PR TITLE
Persist best score using shared preferences

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'dart:async';
 import 'dart:math';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   runApp(const MyApp());
@@ -50,12 +51,13 @@ class _SnakeGameState extends State<SnakeGame> {
   int score = 0;
   int bestScore = 0;
   Timer? gameTimer;
-  
+
   final Random random = Random();
 
   @override
   void initState() {
     super.initState();
+    _loadBestScore();
     _generateFood();
   }
 
@@ -159,12 +161,25 @@ class _SnakeGameState extends State<SnakeGame> {
         score++;
         if (score > bestScore) {
           bestScore = score;
+          _saveBestScore();
         }
         _generateFood();
       } else {
         snake.removeLast();
       }
     });
+  }
+
+  Future<void> _loadBestScore() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      bestScore = prefs.getInt('best_score') ?? 0;
+    });
+  }
+
+  Future<void> _saveBestScore() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('best_score', bestScore);
   }
 
   void _gameOver() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
+  shared_preferences: ^2.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Add `shared_preferences` dependency for storing local values
- Load best score on startup and save new highs for persistence

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b20c3fdc408333a123bfe0a33086c8