### PR TITLE
feat: tap board to start snake game

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -291,20 +291,31 @@ class _SnakeGameState extends State<SnakeGame> {
                 // Game Board
                 Expanded(
                   child: Center(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        border: Border.all(color: Colors.brown, width: 4),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: CustomPaint(
-                        size: Size(
-                          boardSize * cellSize,
-                          boardSize * cellSize,
+                    child: GestureDetector(
+                      onTap: () {
+                        if (isGameRunning) {
+                          // Do nothing when the game is running
+                        } else if (isPaused) {
+                          _resumeGame();
+                        } else {
+                          _startGame();
+                        }
+                      },
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.brown, width: 4),
+                          borderRadius: BorderRadius.circular(8),
                         ),
-                        painter: GamePainter(
-                          snake: snake,
-                          food: food,
-                          cellSize: cellSize,
+                        child: CustomPaint(
+                          size: Size(
+                            boardSize * cellSize,
+                            boardSize * cellSize,
+                          ),
+                          painter: GamePainter(
+                            snake: snake,
+                            food: food,
+                            cellSize: cellSize,
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- allow starting or resuming the game by tapping the play area

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2936965b083339b2eb81214d32048